### PR TITLE
Add case insensitive option for AutoEqualityAttribute

### DIFF
--- a/Generators/AutoEquality.cs
+++ b/Generators/AutoEquality.cs
@@ -188,26 +188,20 @@ using System.Collections.Generic;");
                 builder.AppendLine($@"
 {indent.Value}public override int GetHashCode()
 {indent.Value}{{
-{indent.Value2}return HashCode.Combine(");
+{indent.Value2}var hash = new HashCode();");
 
-                using var marker = indent.Increase(2);
-
-                // TODO: handle more than eight fields
                 for (var i = 0; i < memberInfoList.Count; i++)
                 {
                     var current = memberInfoList[i];
-                    builder.Append($"{indent.Value}{current.Name}");
-                    if (i + 1 < memberInfoList.Count)
+                    builder.AppendLine($"{indent.Value2}hash.Add({current.Name});");
+
+                    if (i + 1 >= memberInfoList.Count)
                     {
-                        builder.AppendLine(",");
-                    }
-                    else
-                    {
-                        builder.AppendLine(");");
+                        builder.AppendLine();
+                        builder.AppendLine($"{indent.Value2}return hash.ToHashCode();");
                     }
                 }
 
-                marker.Revert();
                 builder.AppendLine($"{indent.Value}}}");
             }
 

--- a/Generators/AutoEquality.cs
+++ b/Generators/AutoEquality.cs
@@ -162,10 +162,10 @@ using System.Collections.Generic;");
 
                 for (var i = 0; i < memberInfoList.Count; i++)
                 {
-                    var (name, typeName, useOperator) = memberInfoList[i];
+                    var (name, typeName, useOperator, isString) = memberInfoList[i];
                     var line = (
                         useOperator,
-                        isString: typeName.Equals("string", StringComparison.OrdinalIgnoreCase)) switch
+                        isString) switch
                     {
                         (true, _) => $"{indent.Value}{name} == other.{name}",
                         (_, true) => isCaseInsensitive
@@ -219,10 +219,18 @@ using System.Collections.Generic;");
                     switch (symbol)
                     {
                         case IFieldSymbol { Type: { }, IsImplicitlyDeclared: false } fieldSymbol:
-                            list.Add(new MemberInfo(fieldSymbol.Name, fieldSymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), UseOperator(fieldSymbol.Type)));
+                            list.Add(new(
+                                fieldSymbol.Name, 
+                                fieldSymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                                UseOperator(fieldSymbol.Type),
+                                IsString(fieldSymbol.Type)));
                             break;
                         case IPropertySymbol { IsIndexer: false, GetMethod: { } } propertySymbol:
-                            list.Add(new MemberInfo(propertySymbol.Name, propertySymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), UseOperator(propertySymbol.Type)));
+                            list.Add(new(
+                                propertySymbol.Name, 
+                                propertySymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), 
+                                UseOperator(propertySymbol.Type),
+                                IsString(propertySymbol.Type)));
                             break;
                         default:
                             break;
@@ -244,10 +252,15 @@ using System.Collections.Generic;");
                             SpecialType.System_IntPtr or
                             SpecialType.System_UIntPtr
                     };
+
+                static bool IsString(ITypeSymbol? type) =>
+                    type is { SpecialType: SpecialType.System_String };
             }
         }
 
-        private record MemberInfo(string Name, string TypeName, bool UseOperator);
+        private record MemberInfo(
+            string Name, string TypeName,
+            bool UseOperator, bool IsString);
 
         /// <summary>
         /// Created on demand before each generation pass

--- a/Generators/AutoEquality.cs
+++ b/Generators/AutoEquality.cs
@@ -168,7 +168,7 @@ using System.Collections.Generic;");
                         isString: typeName.Equals("string", StringComparison.OrdinalIgnoreCase)) switch
                     {
                         (true, _) => $"{indent.Value}{name} == other.{name}",
-                        (false, true) => isCaseInsensitive
+                        (_, true) => isCaseInsensitive
                             ? $"{indent.Value}string.Equals({name}, other.{name}, StringComparison.OrdinalIgnoreCase)"
                             : $"{indent.Value}string.Equals({name}, other.{name})",
                         _ => $"{indent.Value}EqualityComparer<{typeName}>.Default.Equals({name}, other.{name})"

--- a/Generators/AutoEquality.cs
+++ b/Generators/AutoEquality.cs
@@ -195,7 +195,7 @@ using System.Collections.Generic;");
                     var current = memberInfoList[i];
                     builder.AppendLine($"{indent.Value2}hash.Add({current.Name});");
 
-                    if (i + 1 >= memberInfoList.Count)
+                    if (i + 1 == memberInfoList.Count)
                     {
                         builder.AppendLine();
                         builder.AppendLine($"{indent.Value2}return hash.ToHashCode();");

--- a/Generators/AutoEquality.cs
+++ b/Generators/AutoEquality.cs
@@ -1,14 +1,9 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
-using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
-using System.Reflection.Metadata;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Generators
@@ -38,7 +33,7 @@ internal sealed class AutoEqualityAttribute : Attribute
             // add the attribute text
             context.AddSource("AutoEqualityAttribute", SourceText.From(attributeText, Encoding.UTF8));
 
-            if (!(context.SyntaxReceiver is SyntaxReceiver receiver))
+            if (context.SyntaxReceiver is not SyntaxReceiver receiver)
                 return;
 
             // TODO: should verify the name
@@ -50,7 +45,8 @@ internal sealed class AutoEqualityAttribute : Attribute
                 {
                     if (semanticModel.GetDeclaredSymbol(decl) is { } namedTypeSymbol)
                     {
-                        var isAnnotated = context.Compilation.Options.NullableContextOptions == NullableContextOptions.Enable ||
+                        var isAnnotated =
+                            context.Compilation.Options.NullableContextOptions == NullableContextOptions.Enable ||
                             semanticModel.GetNullableContext(decl.SpanStart) == NullableContext.Enabled;
                         list.Add((namedTypeSymbol, isAnnotated));
                     }
@@ -62,7 +58,8 @@ internal sealed class AutoEqualityAttribute : Attribute
             context.AddSource("GeneratedEquality", SourceText.From(builder.ToString(), Encoding.UTF8));
         }
 
-        private void AddTypeGeneration(StringBuilder builder, IEnumerable<(INamedTypeSymbol NamedTypeSymbol, bool IsAnnotated)> typeSymbols)
+        private void AddTypeGeneration(
+            StringBuilder builder, IEnumerable<(INamedTypeSymbol NamedTypeSymbol, bool IsAnnotated)> typeSymbols)
         {
             if (!typeSymbols.Any())
             {
@@ -95,7 +92,8 @@ using System.Collections.Generic;");
             }
         }
 
-        private void AddTypeGeneration(StringBuilder builder, IndentUtil indent, INamedTypeSymbol typeSymbol, bool isAnnotated)
+        private void AddTypeGeneration(
+            StringBuilder builder, IndentUtil indent, INamedTypeSymbol typeSymbol, bool isAnnotated)
         {
             var kind = typeSymbol.TypeKind == TypeKind.Class ? "class" : "struct";
 
@@ -232,18 +230,19 @@ using System.Collections.Generic;");
 
                 return list;
 
-                bool UseOperator(ITypeSymbol? type) =>
-                    type is { } &&
-                    type.SpecialType is
-                        SpecialType.System_Int16 or
-                        SpecialType.System_Int32 or
-                        SpecialType.System_Int64 or
-                        SpecialType.System_UInt16 or
-                        SpecialType.System_UInt32 or
-                        SpecialType.System_UInt64 or
-                        SpecialType.System_String or
-                        SpecialType.System_IntPtr or
-                        SpecialType.System_UIntPtr;
+                static bool UseOperator(ITypeSymbol? type) =>
+                    type is
+                    {
+                        SpecialType:
+                            SpecialType.System_Int16 or
+                            SpecialType.System_Int32 or
+                            SpecialType.System_Int64 or
+                            SpecialType.System_UInt16 or
+                            SpecialType.System_UInt32 or
+                            SpecialType.System_UInt64 or
+                            SpecialType.System_IntPtr or
+                            SpecialType.System_UIntPtr
+                    };
             }
         }
 

--- a/Generators/Utils.cs
+++ b/Generators/Utils.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Generators
 {
@@ -23,10 +21,7 @@ namespace Generators
                 _count = 0;
             }
 
-            public void Dispose()
-            {
-                _util.Decrease(_count);
-            }
+            public void Dispose() => _util.Decrease(_count);
         }
 
         public int Depth { get; private set; }
@@ -35,10 +30,7 @@ namespace Generators
         public string Value2 { get; private set; } = "";
         public string Value3 { get; private set; } = "";
 
-        public IndentUtil()
-        {
-            Update();
-        }
+        public IndentUtil() => Update();
 
         public Marker Increase(int count = 1)
         {
@@ -65,5 +57,4 @@ namespace Generators
             Value3 = new string(' ', (Depth + 2) * 4);
         }
     }
-
 }

--- a/GeneratorsUnitTests/AutoEqualityUnitTests.cs
+++ b/GeneratorsUnitTests/AutoEqualityUnitTests.cs
@@ -49,8 +49,10 @@ partial class C : IEquatable<C>
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(
-            Field);
+        var hash = new HashCode();
+        hash.Add(Field);
+
+        return hash.ToHashCode();
     }
 }
 ", GetGeneratedTree(source));
@@ -96,9 +98,11 @@ partial class C : IEquatable<C>
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(
-            Field,
-            Field2);
+        var hash = new HashCode();
+        hash.Add(Field);
+        hash.Add(Field2);
+
+        return hash.ToHashCode();
     }
 }
 #nullable disable
@@ -147,9 +151,11 @@ namespace N
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                Field1,
-                Field2);
+            var hash = new HashCode();
+            hash.Add(Field1);
+            hash.Add(Field2);
+
+            return hash.ToHashCode();
         }
     }
 }
@@ -199,10 +205,12 @@ namespace N
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                Field1,
-                Field2,
-                Field3);
+            var hash = new HashCode();
+            hash.Add(Field1);
+            hash.Add(Field2);
+            hash.Add(Field3);
+
+            return hash.ToHashCode();
         }
     }
 }
@@ -251,9 +259,11 @@ namespace N
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                Field1,
-                Field2);
+            var hash = new HashCode();
+            hash.Add(Field1);
+            hash.Add(Field2);
+
+            return hash.ToHashCode();
         }
     }
 }
@@ -302,9 +312,11 @@ namespace N
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                Field1,
-                Field2);
+            var hash = new HashCode();
+            hash.Add(Field1);
+            hash.Add(Field2);
+
+            return hash.ToHashCode();
         }
     }
 }
@@ -356,9 +368,11 @@ namespace N
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                Field1,
-                Field2);
+            var hash = new HashCode();
+            hash.Add(Field1);
+            hash.Add(Field2);
+
+            return hash.ToHashCode();
         }
     }
 #nullable disable
@@ -410,9 +424,11 @@ namespace N
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                Field1,
-                Field2);
+            var hash = new HashCode();
+            hash.Add(Field1);
+            hash.Add(Field2);
+
+            return hash.ToHashCode();
         }
     }
 #nullable disable

--- a/GeneratorsUnitTests/AutoEqualityUnitTests.cs
+++ b/GeneratorsUnitTests/AutoEqualityUnitTests.cs
@@ -1,10 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
-using System;
-using Xunit;
+﻿using Xunit;
 using Microsoft.CodeAnalysis;
 using System.Linq;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Generators.UnitTests

--- a/GeneratorsUnitTests/AutoEqualityUnitTests.cs
+++ b/GeneratorsUnitTests/AutoEqualityUnitTests.cs
@@ -56,8 +56,6 @@ partial class C : IEquatable<C>
 ", GetGeneratedTree(source));
 
             VerifyCompiles(source);
-
-
         }
 
         [Fact]
@@ -72,6 +70,7 @@ using System;
 partial class C
 {
     Exception Field = new();
+    string Field2 = null!;
 }
 
 ";
@@ -91,13 +90,15 @@ partial class C : IEquatable<C>
     {
         return
             other is object &&
-            EqualityComparer<global::System.Exception>.Default.Equals(Field, other.Field);
+            EqualityComparer<global::System.Exception>.Default.Equals(Field, other.Field) &&
+            string.Equals(Field2, other.Field2);
     }
 
     public override int GetHashCode()
     {
         return HashCode.Combine(
-            Field);
+            Field,
+            Field2);
     }
 }
 #nullable disable
@@ -155,8 +156,6 @@ namespace N
 ", GetGeneratedTree(source));
 
             VerifyCompiles(source);
-
-
         }
 
         [Fact]
@@ -168,7 +167,7 @@ using System;
 
 namespace N
 {
-    [AutoEquality]
+    [AutoEquality(CaseInsensitive = true)]
     partial struct S
     {
         int Field1;
@@ -194,7 +193,7 @@ namespace N
         {
             return
                 Field1 == other.Field1 &&
-                Field2 == other.Field2 &&
+                string.Equals(Field2, other.Field2, StringComparison.OrdinalIgnoreCase) &&
                 EqualityComparer<global::System.Exception>.Default.Equals(Field3, other.Field3);
         }
 
@@ -210,8 +209,6 @@ namespace N
 ", GetGeneratedTree(source));
 
             VerifyCompiles(source);
-
-
         }
 
         [Fact]
@@ -263,8 +260,57 @@ namespace N
 ", GetGeneratedTree(source));
 
             VerifyCompiles(source);
+        }
 
+        [Fact]
+        public void NamespaceMultiplePropertiesWithCaseInsensitivity()
+        {
+            var source = @"
+using System;
+#pragma warning disable 649
 
+namespace N
+{
+    [AutoEquality(caseInsensitive: true)]
+    partial class C
+    {
+        string Field1 { get; }
+        string Field2 { get; }
+    }
+}
+";
+
+            VerifyGeneratedCode(@"
+using System;
+using System.Collections.Generic;
+namespace N
+{
+
+    partial class C : IEquatable<C>
+    {
+        public override bool Equals(object obj) => obj is C other && Equals(other);
+        public static bool operator==(C left, C right) => left is object && left.Equals(right);
+        public static bool operator!=(C left, C right) => !(left == right);
+
+        public bool Equals(C other)
+        {
+            return
+                other is object &&
+                string.Equals(Field1, other.Field1, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(Field2, other.Field2, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Field1,
+                Field2);
+        }
+    }
+}
+", GetGeneratedTree(source));
+
+            VerifyCompiles(source);
         }
 
         [Fact]
@@ -320,8 +366,6 @@ namespace N
 ", GetGeneratedTree(source));
 
             VerifyCompiles(source);
-
-
         }
 
         [Fact]
@@ -376,8 +420,6 @@ namespace N
 ", GetGeneratedTree(source));
 
             VerifyCompiles(source);
-
-
         }
     }
 }


### PR DESCRIPTION
Add case insensitive option for `AutoEqualityAttribute`. All unit tests pass, and added one and tweaked a few existing for good measure.

- Minor clean up:
  - Remove un-used `usings`
  - A few opportunities for pattern matching
  - Switch expressions instead of if/else
  - Ternary operator where appropriate
  - Expression bodied members
 - Address `TODO` handle more than 8 members in `GetHashCode`

With these changes one could do this:

```csharp
[AutoEquality(CaseInsensitive = true)]
public class Example
{
    public string Value { get; }
}
```

Then the auto equality comparison will account for `string` members and treat them with `StringComparison.OrdinalIgnoreCase`.